### PR TITLE
stdout is useful for errors as well

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,9 @@ export default (cmd, args, options = {}) => new Promise((resolve, reject) => {
     if (code !== 0) {
       const err = new Error(`Exited with status ${code}`)
       err.exitStatus = code
+      if (!ignoreStdout) {
+        err.stdout = Buffer.concat(stdout)
+      }
       if (!ignoreStderr) {
         err.stderr = Buffer.concat(stderr)
       }


### PR DESCRIPTION
not all executables log their errors on stderr
