### PR TITLE
fix: error when {encoding} was set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,9 +54,6 @@ export default (cmd, args, options = {}) => {
     let stdout = null
     let stderr = null
     const [ignoreStdout, ignoreStderr] = parseStdioOption(options.stdio)
-    if (encoding) {
-      childProcess.stdin.setEncoding(encoding)
-    }
     if (!ignoreStdout) {
       stdout = []
       if (encoding) {


### PR DESCRIPTION
When using {encoding} option this was giving an error: TypeError: Cannot read property 'setEncoding' of null

setEncoding can only be done on a readable it seems

https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding