### PR TITLE
Use real SpawnOptions as base for cross spawn promise options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,13 +6,16 @@
  * @param {Partial<crossSpawnPromise.CrossSpawnOptions>} [options] additional options.
  * @returns {Promise<Uint8Array>} a promise result with `stdout`
  */
+
+/// <reference types="node" />
+
 declare function crossSpawnPromise(cmd: string, args?: any[], options?: Partial<crossSpawnPromise.CrossSpawnOptions>): Promise<Uint8Array>;
 
-declare namespace crossSpawnPromise {
+import * as child_process from 'child_process';
 
-	interface CrossSpawnOptions {
+declare namespace crossSpawnPromise {
+	interface CrossSpawnOptions extends child_process.SpawnOptions {
 		encoding: string;
-		stdio: string;
 	}
 
 	interface CrossSpawnError {


### PR DESCRIPTION
This will require people using the types to install `@types/node`, but this will help transparently ensure that the type definitions work with any options. Currently, TypeScript will complain to you when using any options other than `stdio`. 